### PR TITLE
Modification of Monte-Carlo integration

### DIFF
--- a/commonmethods/internals.py
+++ b/commonmethods/internals.py
@@ -249,4 +249,4 @@ class redundantInternals(molGraph):
 
     def getBondPartner(self): 
         for i in np.arange(1, self.BLConnectivity.size):
-            print self.atomNames[self.BLConnectivity[i]], self.atomNames[i]
+            print(self.atomNames[self.BLConnectivity[i]], self.atomNames[i])


### PR DESCRIPTION
The original importance sampling function in Ref. [1] turns out to be suboptimal since it represents an incoherent sum of TBFs. For this reason, it is not ensured that the resulting estimate of the reduced density is normalised. If, however, the Mulliken population of the TBFs is used, then the importance sampling function is normalised and actually corresponds to the AIMS density itself. Hence equation (10)  in Ref. [1] reduces to the definition of a histogram, and the estimated reduced density is forced to integrate to one. This is what this PR proposes to implement. 

---

[1] [Coe, J. D.; Levine, B. G.; Martı́nez, T. J. *J. Phys. Chem. A* **2007**, 111, 11302-11310](https://doi.org/10.1021/jp072027b)